### PR TITLE
Fix SellPriceVariance randomness

### DIFF
--- a/AHBot.lua
+++ b/AHBot.lua
@@ -674,7 +674,7 @@ function AHBot_Buy_ProcessTransactions(underpricedItems, auctionResults)
                         transactionType = "buyout"
                         price = matchingAuction.buyoutprice
                     else
-                        price = math.random(minBid, maxBid)
+                        price = randomFloatBetween(minBid, maxBid)
                     end
                 end
                 
@@ -912,9 +912,7 @@ local function ProcessItemCreation(selectedItems, houseId, availableGuids, avail
             cost = cost * stack
             
             if SellPriceVariance then
-                local minCost = cost * (1 - (SellPriceVariance/100))
-                local maxCost = cost * (1 + (SellPriceVariance/100))
-                cost = math.random(math.floor(minCost), math.floor(maxCost))
+                cost = cost * randomFloatBetween(1 - (SellPriceVariance/100), 1 + (SellPriceVariance/100))
             end
             
             cost = math.floor(cost)

--- a/AHBot.lua
+++ b/AHBot.lua
@@ -912,7 +912,9 @@ local function ProcessItemCreation(selectedItems, houseId, availableGuids, avail
             cost = cost * stack
             
             if SellPriceVariance then
-                cost = cost * math.random(1 - (SellPriceVariance/100), 1 + (SellPriceVariance/100))
+                local minCost = cost * (1 - (SellPriceVariance/100))
+                local maxCost = cost * (1 + (SellPriceVariance/100))
+                cost = math.random(math.floor(minCost), math.floor(maxCost))
             end
             
             cost = math.floor(cost)

--- a/AHBot/AHBot_Helpers.lua
+++ b/AHBot/AHBot_Helpers.lua
@@ -46,3 +46,8 @@ function getQualityString(Quality)
     }
     return QualityStrings[Quality]
 end
+
+-- Like math.random(a, b) but also works correctly with floating point values.
+function randomFloatBetween(a, b)
+    return a + (math.random() * (b - a))
+end


### PR DESCRIPTION
Closes #13

~There are other instance of `math.random` where the arguments might be floats, but if they are, they are large enough that it wont matter (except when using Lua 5.3, where this will cause errors...).~

All remaining calls to `math.random(a, b)` use integers.